### PR TITLE
Allow 'limit', 'skip' and 'sort' in query params

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -7,7 +7,18 @@ module.exports = function(model) {
     findAll: function*() {
       var error, result;
       try {
-        result = yield model.find(this.request.query).exec();
+        var conditions = {};
+        var query = this.request.query;
+        if (query.conditions) {
+          conditions = JSON.parse(query.conditions);
+        }
+        var builder = model.find(conditions);
+        ['limit', 'skip', 'sort'].forEach(function(key){
+          if (query[key]) {
+            builder[key](query[key]);
+          }
+        })
+        result = yield builder.exec();
         return this.body = result;
       } catch (_error) {
         error = _error;


### PR DESCRIPTION
The get query can now look like this: 
http://localhost:8080/api/cars?conditions={"brand":"ford"}&limit=10&skip=1&sort=-brand