### PR TITLE
pluralize the routes

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,9 +1,12 @@
-var generateRoutes;
+var generateRoutes,
+    pluralize = require('pluralize');
 
 module.exports = generateRoutes = function(app, modelName, actions, prefix) {
   if (prefix == null) {
     prefix = '';
   }
+  modelName = pluralize(modelName);
+
   app.get(prefix + ("/" + modelName), actions.findAll);
   app.get(prefix + ("/" + modelName + "/:id"), actions.findById);
   app.post(prefix + ("/" + modelName), actions.create);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "homepage": "https://github.com/t3chnoboy/koa-mongo-rest",
   "dependencies": {
     "co-body": "^2.0.0",
-    "mongoose": "^4.0.2"
+    "mongoose": "^4.0.2",
+    "pluralize": "1.1.2"
   },
   "devDependencies": {
     "co-mocha": "0.0.2",


### PR DESCRIPTION
This PR allows the module to pluralize the model name so you can have a 'post' or 'user' model which you request from 'posts' and 'users' endpoint and you request /posts/:id  for a single one, which is on par with Rails, MEAN and most other REST implementations.